### PR TITLE
Eliminate jsonmerge dependency

### DIFF
--- a/k_diffusion/config.py
+++ b/k_diffusion/config.py
@@ -3,9 +3,17 @@ import json
 import math
 import warnings
 
-from jsonmerge import merge
-
 from . import augmentation, layers, models, utils
+
+
+def merge_config(defaults, config):
+    result = {**defaults}
+    for key, value in config.items():
+        if isinstance(value, dict):
+            result[key] = merge_config(result.get(key, {}), value)
+        else:
+            result[key] = value
+    return result
 
 
 def load_config(file):
@@ -46,7 +54,7 @@ def load_config(file):
         },
     }
     config = json.load(file)
-    return merge(defaults, config)
+    return merge_config(defaults, config)
 
 
 def make_model(config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ accelerate
 clean-fid
 clip-anytorch
 einops
-jsonmerge
 kornia
 Pillow
 resize-right

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ install_requires =
     clean-fid
     clip-anytorch
     einops
-    jsonmerge
     kornia
     Pillow
     resize-right


### PR DESCRIPTION
The jsonmerge library uses rpds library which can only be imported into a process once but is getting imported via both diffusers and stable_diffusion. This eliminates the jsonmerge dependency.